### PR TITLE
add source url for drifter metadata

### DIFF
--- a/drifterMeta.py
+++ b/drifterMeta.py
@@ -52,6 +52,9 @@ driftermetaSchema = {
         },
         "typebuoy": {
             "bsonType": "string"
+        },
+        "source_url": {
+            "bsonType": "string"
         }
     }
 }


### PR DESCRIPTION
yes, this is a bit unorthodox, as the drifter data nominally obeys the point data schema, which would put `source_url` in `source_info[{source_url}]`, but since `source_info[{source}]` must live on the point document (so in `drifters` collection), and there's a zillion of these for each file, putting the URL there too would cause a bunch of bloat which I'd rather avoid.