### PR TITLE
rethinking grid packing

### DIFF
--- a/grids-meta.py
+++ b/grids-meta.py
@@ -7,7 +7,7 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'gridMetax'
+metacollection = 'gridMeta'
 
 db[metacollection].drop()
 db.create_collection(metacollection)

--- a/grids-meta.py
+++ b/grids-meta.py
@@ -7,33 +7,20 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'gridMeta'
+metacollection = 'gridMetax'
 
 db[metacollection].drop()
 db.create_collection(metacollection)
 
 gridmetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "data_type", "data_keys", "units", "date_updated_argovis", "source", "levels", "lonrange", "latrange", "timerange", "loncell", "latcell"],
+    "required": ["_id", "data_type", "date_updated_argovis", "source", "levels"],
     "properties":{
         "_id": {
             "bsonType": "string"
         },
         "data_type": {
             "bsonType": "string"
-        },
-        "data_keys": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "string",
-                "enum": ["ohc_kg", "temperature_rg", "salinity_rg"]
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
         },
         "date_updated_argovis": {
             "bsonType": "date"
@@ -67,36 +54,6 @@ gridmetaSchema = {
             "items": {
                 "bsonType": ["double", "int"]
             }
-        },
-        "lonrange": {
-            "bsonType": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {
-                "bsonType": ["double", "int"]
-            }
-        },
-        "latrange": {
-            "bsonType": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {
-                "bsonType": ["double", "int"]
-            }
-        },
-        "timerange": {
-            "bsonType": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {
-                "bsonType": ["date"]
-            }
-        },
-        "loncell": {
-            "bsonType": ["double", "int"]
-        },
-        "latcell": {
-            "bsonType": ["double", "int"]
         }
     }
 }

--- a/grids.py
+++ b/grids.py
@@ -13,13 +13,16 @@ db.create_collection(grid)
 
 gridSchema = {
     "bsonType": "object",
-    "required": ["_id", "metadata","geolocation","data","basin","timestamp"],
+    "required": ["_id", "metadata","geolocation","data","data_keys","basin","timestamp","units"],
     "properties": {
         "_id": {
             "bsonType": "string"
         },
         "metadata": {
-            "bsonType": "string"
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "geolocation": {
             "bsonType": "object",
@@ -51,6 +54,19 @@ gridSchema = {
                 "items": {
                     "bsonType": ["double", "int", "null"]
                 }
+            }
+        },
+        "data_keys": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string",
+                "enum": ["rg09_temperature", "rg09_salinity", "kg21_ohc15to300"]
+            }
+        },
+        "units": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": ["string", "null"]
             }
         }
     }


### PR DESCRIPTION
Goal is to combine all grids with identical latices into a single collection, thus reducing index sizes. Follows existing data schema as closely as possible, except:

 - `metadata` has to be an array, as different products (ie rg, kg) can end up on the same grid and thus the same data documents.
 - `data` is most efficiently packed as `data[i][j]` where `i` indexes gridded product and `j` indexes levels, to accommodate factoring out depths to the metadata and even having different level measures (eg some products may use depth versus others with pressure on the same long/lat/time lattice). This is effectively the transpose of the point data.