### PR TITLE
covar schema

### DIFF
--- a/covar.py
+++ b/covar.py
@@ -54,7 +54,7 @@ covarianceMetaSchema = {
         "levels": {
             "bsonType": "array",
             "items": {
-                "bsonType": ["int"]
+                "bsonType": ["int", "double"]
             }      
         }
        


### PR DESCRIPTION
mongo shell interpreted `0` as a double, so.