### PR TITLE
rc data schema

### DIFF
--- a/argo.py
+++ b/argo.py
@@ -99,8 +99,13 @@ argoSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
-            "bsonType": "object",
-            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in argo_measurements}
+            "bsonType": "array",
+            "items": {
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["double", "int", "string", "null"]
+                }
+            }
         },
         "measurement_metadata": {
             "bsonType": "array",

--- a/argo.py
+++ b/argo.py
@@ -73,7 +73,10 @@ argoSchema = {
             "bsonType": "string"
         },
         "metadata": {
-            "bsonType": "string"
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "geolocation": {
             "bsonType": "object",
@@ -107,7 +110,7 @@ argoSchema = {
                 }
             }
         },
-        "measurement_metadata": {
+        "data_info": {
             "bsonType": "array",
             "items": {
                 "bsonType": "array",

--- a/argo.py
+++ b/argo.py
@@ -10,10 +10,10 @@ db = client.argo
 metacollection = 'argoMeta'
 datacollection = 'argo'
 
-# db[metacollection].drop()
-# db.create_collection(metacollection)
-# db[datacollection].drop()
-# db.create_collection(datacollection)
+db[metacollection].drop()
+db.create_collection(metacollection)
+db[datacollection].drop()
+db.create_collection(datacollection)
 
 argo_vars = ["bbp470","bbp532","bbp700","bbp700_2","bisulfide","cdom","chla","cndc","cndx","cp660","down_irradiance380","down_irradiance412","down_irradiance442","down_irradiance443","down_irradiance490","down_irradiance555","down_irradiance670","downwelling_par","doxy","doxy2","doxy3","molar_doxy","nitrate","ph_in_situ_total","pressure","salinity","salinity_sfile","temperature","temperature_sfile","turbidity","up_radiance412","up_radiance443","up_radiance490","up_radiance555"]
 argo_measurements = argo_vars + [x+'_std' for x in argo_vars] + [x+'_med' for x in argo_vars]
@@ -28,19 +28,6 @@ argoMetaSchema = {
         },
         "data_type": {
             "bsonType": "string"
-        },
-        "data_keys": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "string",
-                "enum": argo_measurements
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
         },
         "country": {
             "bsonType": "string"
@@ -112,11 +99,15 @@ argoSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
+            "bsonType": "object",
+            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in argo_measurements}
+        },
+        "measurement_metadata": {
             "bsonType": "array",
             "items": {
                 "bsonType": "array",
                 "items": {
-                    "bsonType": ["double", "int", "string", "null"]
+                    "bsonType": ["string", "array"]
                 }
             }
         },
@@ -154,27 +145,8 @@ argoSchema = {
                 "enum": ["degenerate_levels", "missing_basin", "missing_location", "missing_timestamp"]
             }
         },
-        "data_keys": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "string",
-                "enum": argo_measurements
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
-        },
         "cycle_number": {
             "bsonType": "int"
-        },
-        "data_keys_mode": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
         },
         "geolocation_argoqc": {
             "bsonType": "int"

--- a/cchdo.py
+++ b/cchdo.py
@@ -60,13 +60,16 @@ cchdometaSchema = {
 
 cchdoSchema = {
     "bsonType": "object",
-    "required": ["_id","metadata","geolocation","data","basin","timestamp", "data_keys", "units", "source", "station", "cast"],
+    "required": ["_id","metadata","geolocation","data","basin","timestamp", "data_info", "source", "station", "cast"],
     "properties": {
         "_id": {
             "bsonType": "string"
         },
         "metadata": {
-            "bsonType": "string"
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "geolocation": {
             "bsonType": "object",
@@ -122,19 +125,7 @@ cchdoSchema = {
                 "enum": ["degenerate_levels", "missing_basin", "missing_location", "missing_timestamp"]
             }
         },
-        "data_keys": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "string",
-                "enum": ["ammonium_btl","ammonium_btl_woceqc","bionbr_btl","bottle_latitude_btl","bottle_longitude_btl","bottle_number_btl","bottle_number_btl_woceqc","bottle_salinity_btl","bottle_salinity_btl_woceqc","bottle_time_btl","carbon_tetrachloride_btl","carbon_tetrachloride_btl_woceqc","cfc_113_btl","cfc_113_btl_woceqc","cfc_11_btl","cfc_11_btl_woceqc","cfc_12_btl","cfc_12_btl_woceqc","chlorophyll_a_btl","chlorophyll_a_btl_woceqc","chlorophyll_a_ug_kg_btl","chlorophyll_a_ug_kg_btl_woceqc","co2_mole_fraction_btl","co2_mole_fraction_btl_woceqc","ctd_beamcp_ctd","ctd_beamcp_ctd_woceqc","ctd_beta700_raw_btl","ctd_beta700_raw_btl_woceqc","ctd_beta700_raw_ctd","ctd_beta700_raw_ctd_woceqc","ctd_cdom_raw_ctd","ctd_cdom_raw_ctd_woceqc","ctd_fluor_arbitrary_ctd","ctd_fluor_ctd","ctd_fluor_ctd_woceqc","ctd_fluor_raw_btl","ctd_fluor_raw_btl_woceqc","ctd_fluor_raw_ctd","ctd_fluor_raw_ctd_woceqc","ctd_nitrate_ctd","ctd_nitrate_ctd_woceqc","ctd_number_of_observations_ctd","ctd_optode_oxygen_ctd","ctd_optode_oxygen_ctd_woceqc","ctd_optode_oxygen_raw_ctd","ctd_optode_oxygen_raw_ctd_woceqc","ctd_pressure_raw_btl","ctd_temperature_unk_ctd","ctd_temperature_unk_ctd_woceqc","ctd_transmissometer_ctd","ctd_transmissometer_ctd_woceqc","ctd_transmissometer_raw_btl","ctd_transmissometer_raw_btl_woceqc","ctd_transmissometer_raw_ctd","ctd_transmissometer_raw_ctd_woceqc","ctd_turbidity_ntu_ctd","del_carbon_13_dic_btl","del_carbon_13_dic_btl_woceqc","del_carbon_14_dic_btl","del_carbon_14_dic_btl_woceqc","del_carbon_14_dic_error_btl","del_oxygen_18_btl","del_oxygen_18_btl_woceqc","del_oxygen_18_error_btl","delta_helium_3_btl","delta_helium_3_btl_woceqc","delta_helium_3_error_btl","dissolved_organic_carbon_btl","dissolved_organic_carbon_btl_woceqc","fm_depth_btl","fm_depth_ctd","fm_depth_ctd_woceqc","geotraces_sample_btl","helium_btl","helium_btl_woceqc","helium_error_btl","methyl_chloroform_btl","methyl_chloroform_btl_woceqc","neon_btl","neon_btl_woceqc","neon_error_btl","nitrate_btl","nitrate_btl_woceqc","nitrite_btl","nitrite_btl_woceqc","nitrite_nitrate_btl","nitrite_nitrate_btl_woceqc","nitrous_oxide_btl","nitrous_oxide_btl_woceqc","odf_pressure_btl","oxygen_btl","oxygen_btl_woceqc","oxygen_ctd","oxygen_ctd_woceqc","oxygen_ml_l_btl","oxygen_ml_l_btl_woceqc","package_depth_btl","par_ctd","par_ctd_woceqc","partial_co2_temperature_btl","partial_pressure_of_co2_btl","partial_pressure_of_co2_btl_woceqc","particulate_organic_carbon_btl","particulate_organic_carbon_btl_woceqc","particulate_organic_nitrogen_btl","particulate_organic_nitrogen_btl_woceqc","ph_sws_btl","ph_sws_btl_woceqc","ph_temperature_btl","ph_total_h_scale_btl","ph_total_h_scale_btl_woceqc","ph_unknown_scale_btl","ph_unknown_scale_btl_woceqc","phaeophytin_btl","phaeophytin_btl_woceqc","phaeophytin_ug_l_btl","phaeophytin_ug_l_btl_woceqc","phosphate_btl","phosphate_btl_woceqc","potential_temperature_68_btl","potential_temperature_c_btl","potential_temperature_c_ctd","pressure","pressure_btl_woceqc","pressure_ctd_woceqc","ref_temperature_btl","ref_temperature_btl_woceqc","ref_temperature_c_btl","ref_temperature_c_btl_woceqc","reference_salinity_btl","reference_salinity_btl_woceqc","rev_pressure_btl","rev_pressure_btl_woceqc","rev_temperature_90_btl","rev_temperature_90_btl_woceqc","rev_temperature_btl","rev_temperature_btl_woceqc","rev_temperature_c_btl","rev_temperature_c_btl_woceqc","salinity_btl","salinity_btl_woceqc","salinity_ctd","salinity_ctd_woceqc","sample_btl","sample_ctd","silicate_btl","silicate_btl_woceqc","sm_depth_btl","sm_depth_ctd","sm_depth_ctd_woceqc","sulfur_hexifluoride_btl","sulfur_hexifluoride_btl_woceqc","temperature_btl","temperature_btl_woceqc","temperature_ctd","temperature_ctd_woceqc","total_alkalinity_btl","total_alkalinity_btl_woceqc","total_carbon_btl","total_carbon_btl_woceqc","total_dissolved_nitrogen_btl","total_dissolved_nitrogen_btl_woceqc","total_organic_carbon_l_btl","total_organic_carbon_l_btl_woceqc","tritium_btl","tritium_btl_woceqc","tritium_error_btl","urea_btl","urea_btl_woceqc","user_bottle_number_btl","user_bottle_number_btl_woceqc","user_sample_number_btl"]
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
-        },
+        
         "station": {
             "bsonType": "string"
         },
@@ -147,6 +138,15 @@ cchdoSchema = {
                 "bsonType": "array",
                 "items": {
                     "bsonType": ["double", "int", "string", "null"]
+                }
+            }
+        },
+        "data_info": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["string", "array"]
                 }
             }
         }

--- a/drifters.py
+++ b/drifters.py
@@ -152,11 +152,11 @@ drifterSchema = {
 }
 
 db.command('collMod',metacollection, validator={"$jsonSchema": driftermetaSchema}, validationLevel='strict')
-db[metacollection].create_index([("wmo", 1)])
-db[metacollection].create_index([("platform", 1)])
+#db[metacollection].create_index([("wmo", 1)])
+#db[metacollection].create_index([("platform", 1)])
 
 db.command('collMod',datacollection, validator={"$jsonSchema": drifterSchema}, validationLevel='strict')
-db[datacollection].create_index([("metadata", 1)])
-db[datacollection].create_index([("timestamp", -1), ("geolocation", "2dsphere")])
-db[datacollection].create_index([("geolocation", "2dsphere")])
-db[datacollection].create_index([("timestamp", -1)])
+#db[datacollection].create_index([("metadata", 1)])
+#db[datacollection].create_index([("timestamp", -1), ("geolocation", "2dsphere")])
+#db[datacollection].create_index([("geolocation", "2dsphere")])
+#db[datacollection].create_index([("timestamp", -1)])

--- a/drifters.py
+++ b/drifters.py
@@ -7,8 +7,8 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'drifterMetax'
-datacollection = 'drifterx'
+metacollection = 'drifterMeta'
+datacollection = 'drifter'
 
 db[metacollection].drop()
 db.create_collection(metacollection)
@@ -152,11 +152,11 @@ drifterSchema = {
 }
 
 db.command('collMod',metacollection, validator={"$jsonSchema": driftermetaSchema}, validationLevel='strict')
-#db[metacollection].create_index([("wmo", 1)])
-#db[metacollection].create_index([("platform", 1)])
+db[metacollection].create_index([("wmo", 1)])
+db[metacollection].create_index([("platform", 1)])
 
 db.command('collMod',datacollection, validator={"$jsonSchema": drifterSchema}, validationLevel='strict')
-#db[datacollection].create_index([("metadata", 1)])
-#db[datacollection].create_index([("timestamp", -1), ("geolocation", "2dsphere")])
-#db[datacollection].create_index([("geolocation", "2dsphere")])
-#db[datacollection].create_index([("timestamp", -1)])
+db[datacollection].create_index([("metadata", 1)])
+db[datacollection].create_index([("timestamp", -1), ("geolocation", "2dsphere")])
+db[datacollection].create_index([("geolocation", "2dsphere")])
+db[datacollection].create_index([("timestamp", -1)])

--- a/drifters.py
+++ b/drifters.py
@@ -7,8 +7,8 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'drifterMeta'
-datacollection = 'drifter'
+metacollection = 'drifterMetax'
+datacollection = 'drifterx'
 
 db[metacollection].drop()
 db.create_collection(metacollection)
@@ -17,7 +17,7 @@ db.create_collection(datacollection)
 
 driftermetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "rowsize", "wmo", "expno", "deploy_date", "deploy_lon", "deploy_lat", "end_date", "end_lon", "end_lat", "drogue_lost_date", "typedeath", "typebuoy", "data_type", "date_updated_argovis", "source", "measurement_metadata", "platform"],
+    "required": ["_id", "rowsize", "wmo", "expno", "deploy_date", "deploy_lon", "deploy_lat", "end_date", "end_lon", "end_lat", "drogue_lost_date", "typedeath", "typebuoy", "data_type", "date_updated_argovis", "source", "data_info", "platform"],
     "properties":{
         "_id": {
             "bsonType": "string"
@@ -25,7 +25,7 @@ driftermetaSchema = {
         "data_type": {
             "bsonType": "string"
         },
-        "measurement_metadata": {
+        "data_info": {
             "bsonType": "array",
             "items": {
                 "bsonType": "array",
@@ -99,12 +99,6 @@ driftermetaSchema = {
         },
         "typebuoy": {
             "bsonType": "string"
-        },
-        "long_name": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
-            }
         }
     }
 }
@@ -117,7 +111,10 @@ drifterSchema = {
             "bsonType": "string"
         },
         "metadata": {
-            "bsonType": "string"
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "geolocation": {
             "bsonType": "object",

--- a/drifters.py
+++ b/drifters.py
@@ -17,7 +17,7 @@ db.create_collection(datacollection)
 
 driftermetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "rowsize", "wmo", "expno", "deploy_date", "deploy_lon", "deploy_lat", "end_date", "end_lon", "end_lat", "drogue_lost_date", "typedeath", "typebuoy", "data_type", "date_updated_argovis", "source", "data_keys", "units", "long_name", "platform"],
+    "required": ["_id", "rowsize", "wmo", "expno", "deploy_date", "deploy_lon", "deploy_lat", "end_date", "end_lon", "end_lat", "drogue_lost_date", "typedeath", "typebuoy", "data_type", "date_updated_argovis", "source", "measurement_metadata", "platform"],
     "properties":{
         "_id": {
             "bsonType": "string"
@@ -25,17 +25,13 @@ driftermetaSchema = {
         "data_type": {
             "bsonType": "string"
         },
-        "data_keys": {
+        "measurement_metadata": {
             "bsonType": "array",
             "items": {
-                "bsonType": "string",
-                "enum": ["ve","vn","err_lon","err_lat","err_ve","err_vn","gap","sst","sst1","sst2","err_sst","err_sst1","err_sst2","flg_sst","flg_sst1","flg_sst2"]
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["string", "array"]
+                }
             }
         },
         "date_updated_argovis": {
@@ -147,14 +143,9 @@ drifterSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "array",
-                "items": {
-                    "bsonType": ["double", "int", "null"]
-                }
-            }
-        }
+            "bsonType": "object",
+            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in ["ve","vn","err_lon","err_lat","err_ve","err_vn","gap","sst","sst1","sst2","err_sst","err_sst1","err_sst2","flg_sst","flg_sst1","flg_sst2"]}
+        },
     }
 }
 

--- a/drifters.py
+++ b/drifters.py
@@ -143,9 +143,14 @@ drifterSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
-            "bsonType": "object",
-            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in ["ve","vn","err_lon","err_lat","err_ve","err_vn","gap","sst","sst1","sst2","err_sst","err_sst1","err_sst2","flg_sst","flg_sst1","flg_sst2"]}
-        },
+            "bsonType": "array",
+            "items": {
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["double", "int", "string", "null"]
+                }
+            }
+        }
     }
 }
 

--- a/grids-meta.py
+++ b/grids-meta.py
@@ -13,7 +13,7 @@ db.create_collection(metacollection)
 
 gridmetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "data_type", "date_updated_argovis", "source", "levels"],
+    "required": ["_id", "data_type", "date_updated_argovis", "source", "levels", "data_info"],
     "properties":{
         "_id": {
             "bsonType": "string"
@@ -52,6 +52,15 @@ gridmetaSchema = {
             "bsonType": "array",
             "items": {
                 "bsonType": ["double", "int"]
+            }
+        },
+        "data_info": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["string", "array"]
+                }
             }
         }
     }

--- a/grids-meta.py
+++ b/grids-meta.py
@@ -1,5 +1,5 @@
 # usage: python grids-meta.py <grid name>
-# creates an empty, unindexed collection in the argo db called grids-meta with schema validation enforcement
+# creates an empty, unindexed collection in the argo db called <grid name> with schema validation enforcement
 
 from pymongo import MongoClient
 import sys

--- a/grids.py
+++ b/grids.py
@@ -13,7 +13,7 @@ db.create_collection(grid)
 
 gridSchema = {
     "bsonType": "object",
-    "required": ["_id", "metadata","geolocation","data","data_keys","basin","timestamp","units"],
+    "required": ["_id", "metadata","geolocation","data","basin","timestamp","data_info"],
     "properties": {
         "_id": {
             "bsonType": "string"
@@ -52,21 +52,17 @@ gridSchema = {
             "items": {
                 "bsonType": "array",
                 "items": {
-                    "bsonType": ["double", "int", "null"]
+                    "bsonType": ["double", "int", "string", "null"]
                 }
             }
         },
-        "data_keys": {
+        "data_info": {
             "bsonType": "array",
             "items": {
-                "bsonType": "string",
-                "enum": ["rg09_temperature", "rg09_salinity", "kg21_ohc15to300"]
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["string", "array"]
+                }
             }
         }
     }

--- a/grids.py
+++ b/grids.py
@@ -13,7 +13,7 @@ db.create_collection(grid)
 
 gridSchema = {
     "bsonType": "object",
-    "required": ["_id", "metadata","geolocation","data","basin","timestamp","data_info"],
+    "required": ["_id", "metadata","geolocation","data","basin","timestamp"],
     "properties": {
         "_id": {
             "bsonType": "string"
@@ -53,15 +53,6 @@ gridSchema = {
                 "bsonType": "array",
                 "items": {
                     "bsonType": ["double", "int", "string", "null"]
-                }
-            }
-        },
-        "data_info": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "array",
-                "items": {
-                    "bsonType": ["string", "array"]
                 }
             }
         }

--- a/tc.py
+++ b/tc.py
@@ -7,8 +7,8 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'tcMeta'
-datacollection = 'tc'
+metacollection = 'tcMetax'
+datacollection = 'tcx'
 
 db[metacollection].drop()
 db.create_collection(metacollection)
@@ -17,7 +17,7 @@ db.create_collection(datacollection)
 
 tcMetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "data_type", "measurement_metadata", "date_updated_argovis", "source", "name", "num"],
+    "required": ["_id", "data_type", "data_info", "date_updated_argovis", "source", "name", "num"],
     "properties":{ 
         "_id": {
             "bsonType": "string"
@@ -25,7 +25,7 @@ tcMetaSchema = {
         "data_type": {
             "bsonType": "string"
         },
-        "measurement_metadata": {
+        "data_info": {
             "bsonType": "array",
             "items": {
                 "bsonType": "array",
@@ -78,7 +78,10 @@ tcSchema = {
             "bsonType": "string"
         },
         "metadata": {
-            "bsonType": "string"
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "geolocation": {
             "bsonType": "object",

--- a/tc.py
+++ b/tc.py
@@ -17,7 +17,7 @@ db.create_collection(datacollection)
 
 tcMetaSchema = {
     "bsonType": "object",
-    "required": ["_id", "data_type", "data_keys", "units", "date_updated_argovis", "source", "name", "num"],
+    "required": ["_id", "data_type", "measurement_metadata", "date_updated_argovis", "source", "name", "num"],
     "properties":{ 
         "_id": {
             "bsonType": "string"
@@ -25,17 +25,13 @@ tcMetaSchema = {
         "data_type": {
             "bsonType": "string"
         },
-        "data_keys": {
+        "measurement_metadata": {
             "bsonType": "array",
             "items": {
-                "bsonType": "string",
-                "enum": ["wind", "surface_pressure"]
-            }
-        },
-        "units": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": ["string", "null"]
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["string", "array"]
+                }
             }
         },
         "date_updated_argovis": {
@@ -108,13 +104,8 @@ tcSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "array",
-                "items": {
-                    "bsonType": ["double", "int", "null"]
-                }
-            }
+            "bsonType": "object",
+            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in ['wind', 'surface_pressure']}
         },
         "record_identifier": {
             "bsonType": "string"

--- a/tc.py
+++ b/tc.py
@@ -104,8 +104,13 @@ tcSchema = {
             "bsonType": ["date", "null"]
         },
         "data": {
-            "bsonType": "object",
-            "properties": {x: {"bsonType": "array", "items": {"bsonType": ["double", "int", "string", "null"]}} for x in ['wind', 'surface_pressure']}
+            "bsonType": "array",
+            "items": {
+                "bsonType": "array",
+                "items": {
+                    "bsonType": ["double", "int", "string", "null"]
+                }
+            }
         },
         "record_identifier": {
             "bsonType": "string"

--- a/tc.py
+++ b/tc.py
@@ -7,8 +7,8 @@ import sys
 client = MongoClient('mongodb://database/argo')
 db = client.argo
 
-metacollection = 'tcMetax'
-datacollection = 'tcx'
+metacollection = 'tcMeta'
+datacollection = 'tc'
 
 db[metacollection].drop()
 db.create_collection(metacollection)


### PR DESCRIPTION
In order to restore harmony between schema for gridded and point data, we make the following updates to the data documents:

 - `data[i][j]` is the ith data variable, at the jth level. Data should always be in descending level order where applicable.
 - `data_info[0]` is the array formerly known as `data_keys`
 - `data_info[1]` is an array of metadata variables that take on a different value per measurement listed in `data_info[0]`. A universal example is `units`, but various data sets have unique additions.
 - `data_info[2][i][j]` is the value corresponding to the ith data variable from `data_info[0]`, for the jth metadata variable from `data_info[1]` (ie, this element is a 2D array with rows labeled by `data_info[0]` and columns by `data_info[1]`)
 - `metadata` is now an array in all cases